### PR TITLE
Fix moduleError: django not found

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import os
 from distutils.command.build import build
 
-from django.core import management
 from setuptools import setup, find_packages
 
 
@@ -14,6 +13,7 @@ except:
 
 class CustomBuild(build):
     def run(self):
+        from django.core import management
         management.call_command('compilemessages', verbosity=1, interactive=False)
         build.run(self)
 


### PR DESCRIPTION
 by moving import after install